### PR TITLE
'stream' cli argument  support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Options:
   --aws_region             AWS Region
   --group                  AWS CloudWatch log group name              [required]
   --prefix                 AWS CloudWatch log stream name prefix
+  --stream                 AWS CloudWatch log stream name, overrides --prefix option.
   --interval               The maxmimum interval (in ms) before flushing the log
                            queue.                                [default: 1000]
 ```

--- a/bin/pino-cloudwatch.js
+++ b/bin/pino-cloudwatch.js
@@ -10,6 +10,7 @@ var argv = yargs
   .describe('aws_region', 'AWS Region')
   .describe('group', 'AWS CloudWatch log group name')
   .describe('prefix', 'AWS CloudWatch log stream name prefix')
+  .describe('stream', 'AWS CloudWatch log stream name, overrides --prefix option')
   .describe('interval', 'The maxmimum interval (in ms) before flushing the log queue.')
   .demand('group')
   .default('interval', 1000)

--- a/lib/cloudwatch-stream.js
+++ b/lib/cloudwatch-stream.js
@@ -18,7 +18,7 @@ function CloudWatchStream (options) {
 
   this.logStreamNamePrefix = options.prefix;
   this.logGroupName = options.group;
-  this.logStreamName = (options.prefix ? options.prefix + '-' : '') + os.hostname() + '-' + process.pid + '-' + new Date().getTime();
+  this.logStreamName = options.stream || (options.prefix ? options.prefix + '-' : '') + os.hostname() + '-' + process.pid + '-' + new Date().getTime();
   this.nextSequenceToken = null;
 
   this.cloudWatchLogs = new AWS.CloudWatchLogs({


### PR DESCRIPTION
Hey. Thanks for your project, I found it very useful but met one small issue regarding stream name generation.
Source of issue is that I don't want to manually manage various stream in Cloudwatch, in my use-case I need to explicitly set stream name. I thought it could be useful not only for me.

It would be cool if you can take a look & merge this PR.

Cheers