### PR TITLE
Replace lodash.reduce with Array.prototype.reduce

### DIFF
--- a/lib/max-size.js
+++ b/lib/max-size.js
@@ -1,10 +1,9 @@
 // max event size is 256kb see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html
 
-const  MAX_SIZE = 262144;
-const reduce = require('lodash.reduce');
+const MAX_SIZE = 262144;
 
 module.exports = function (chunks, nextChunk) {
-  const size = reduce(chunks, function (v, c) { return v + c.length + 26; }, 0);
+  const size = chunks.reduce(function (v, c) { return v + c.length + 26; }, 0);
 
   return (size + nextChunk.length + 26) >=MAX_SIZE;
 };


### PR DESCRIPTION
lodash.reduce worked by pure luck (!) that this dependency is used by another dependency.

So there are two options to resolve this issue:
a) Add it to dependencies
b) Remove its usage