### PR TITLE
add option to pass in error handler function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ typings/
 # dotenv environment variables file
 .env
 
+.idea

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var StdoutStream = require('./lib/stdout-stream');
 var ThrottleStream = require('./lib/throttle-stream');
 var CloudWatchStream = require('./lib/cloudwatch-stream');
 
-module.exports = function (options) {
+module.exports = function (options, errorHandler) {
   options = options || {};
   options.ignoreEmpty = true;
 
@@ -14,6 +14,10 @@ module.exports = function (options) {
 
   chunk.use(require('./lib/max-length'));
   chunk.use(require('./lib/max-size'));
+
+  if (typeof errorHandler === 'function') {
+    log.on('error', errorHandler);
+  }
 
   stdout.pipe(chunk).pipe(throttle).pipe(log);
 


### PR DESCRIPTION
to avoid uncaught exceptions if something goes wrong with the login to AWS or with pushing the logs to CloudWatch, ther should be an option to pass in an error handler on CloudWatchStream