### PR TITLE
Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ Options:
   --stream                 AWS CloudWatch log stream name, overrides --prefix option.
   --interval               The maxmimum interval (in ms) before flushing the log
                            queue.                                [default: 1000]
-  --write_complete_event   Emit an event with this name once the logs are successfully
-                           push / save in AWS CloudWatch Logs
 ```
 ## Options
 
@@ -51,12 +49,6 @@ If you set this to `0` then it will only send logs when:
   * It reaches the maximum size of the logs
 
 __note__: Disabling the interval could mean that logs will *never* be sent to CloudWatch Logs.
-
-### `write_complete_event`: `String`
-
-The `write_complete_event` is the event that will be emitted once the logs are successfully push / save in AWS CloudWatch Logs.
-
-__note__: register the `write_complete_event` event handler in the stream's events object parameter.
 
 ### `aws_access_key_id`: `String`
 
@@ -77,7 +69,11 @@ var pump = require('pump');
 pump(process.stdin, split(), pinoCloudWatch({ group: 'test' }));
 ```
 
-Attach handlers to different writable stream events:
+A `flushed` event is emitted once the logs are successfully pushed / saved in AWS CloudWatch Logs.
+
+__note__: add the `flushed` event handler in the stream's events object parameter if your application flow needs to be notified once the logs are successfully pushed
+
+Attach handlers to different stream events:
 
 ```javascript
 var pinoCloudWatch = require('pino-cloudwatch');
@@ -86,8 +82,8 @@ var streamToCloudWatch = pinoCloudWatch(
         group: 'test'
     },
     {
-        unpipe: (...params) => {
-            // unpipe event triggered
+        flushed: () => {
+            // flushed event triggered
         },
         error: (err) => {
             // error event triggered

--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ var pump = require('pump');
 pump(process.stdin, split(), pinoCloudWatch({ group: 'test' }));
 ```
 
+Attach handlers to different writable stream events:
+
+```javascript
+var pinoCloudWatch = require('pino-cloudwatch');
+var streamToCloudWatch = pinoCloudWatch(
+    {
+        group: 'test'
+    },
+    {
+        unpipe: (...params) => {
+            // unpipe event triggered
+        },
+        error: (err) => {
+            // error event triggered
+        },
+    });
+```
+__note__: A full list of supported events can be found here https://nodejs.org/dist/v10.19.0/docs/api/stream.html#stream_writable_streams
+
 ### Arbitrary logs
 
 Technically `pino-cloudwatch` can send any object mode stream to CloudWatch Logs. This includes *any* text-based log file. For example: tailing a standard log file like nginx access.log.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Options:
   --stream                 AWS CloudWatch log stream name, overrides --prefix option.
   --interval               The maxmimum interval (in ms) before flushing the log
                            queue.                                [default: 1000]
+  --write_complete_event   Emit an event with this name once the logs are successfully
+                           push / save in AWS CloudWatch Logs
 ```
 ## Options
 
@@ -49,6 +51,12 @@ If you set this to `0` then it will only send logs when:
   * It reaches the maximum size of the logs
 
 __note__: Disabling the interval could mean that logs will *never* be sent to CloudWatch Logs.
+
+### `write_complete_event`: `String`
+
+The `write_complete_event` is the event that will be emitted once the logs are successfully push / save in AWS CloudWatch Logs.
+
+__note__: register the `write_complete_event` event handler in the stream's events object parameter.
 
 ### `aws_access_key_id`: `String`
 

--- a/bin/pino-cloudwatch.js
+++ b/bin/pino-cloudwatch.js
@@ -12,6 +12,7 @@ var argv = yargs
   .describe('prefix', 'AWS CloudWatch log stream name prefix')
   .describe('stream', 'AWS CloudWatch log stream name, overrides --prefix option')
   .describe('interval', 'The maxmimum interval (in ms) before flushing the log queue.')
+  .describe('write_complete_event', 'The event that will be emitted once the logs are successfully push / save in AWS CloudWatch Logs')
   .describe('stdout', 'Copy stdin to stdout')
   .demand('group')
   .default('interval', 1000)

--- a/bin/pino-cloudwatch.js
+++ b/bin/pino-cloudwatch.js
@@ -12,7 +12,6 @@ var argv = yargs
   .describe('prefix', 'AWS CloudWatch log stream name prefix')
   .describe('stream', 'AWS CloudWatch log stream name, overrides --prefix option')
   .describe('interval', 'The maxmimum interval (in ms) before flushing the log queue.')
-  .describe('write_complete_event', 'The event that will be emitted once the logs are successfully push / save in AWS CloudWatch Logs')
   .describe('stdout', 'Copy stdin to stdout')
   .demand('group')
   .default('interval', 1000)

--- a/lib/cloudwatch-stream.js
+++ b/lib/cloudwatch-stream.js
@@ -99,8 +99,14 @@ CloudWatchStream.prototype.putLogEvents = function (options, callback) {
     logStreamName: options.logStreamName,
     sequenceToken: options.nextSequenceToken
   }, function (err, data) {
-    options.nextSequenceToken = data && data.nextSequenceToken;
-    callback(err, options);
+    if (err && err.code === 'InvalidSequenceTokenException') {
+      const { expectedSequenceToken } = JSON.parse(this.httpResponse.body.toString())
+      options.nextSequenceToken = expectedSequenceToken;
+      self.putLogEvents(options, callback);
+    } else {
+      options.nextSequenceToken = data && data.nextSequenceToken;
+      callback(err, options);
+    }
   });
 };
 

--- a/lib/cloudwatch-stream.js
+++ b/lib/cloudwatch-stream.js
@@ -19,6 +19,7 @@ function CloudWatchStream (options) {
   this.logGroupName = options.group;
   this.logStreamName = options.stream || (options.prefix ? options.prefix + '-' : '') + os.hostname() + '-' + process.pid + '-' + new Date().getTime();
   this.nextSequenceToken = null;
+  this.writeCompleteEvent = options.write_complete_event || null;
 
   var awsOptions = {};
 
@@ -121,6 +122,11 @@ CloudWatchStream.prototype._write = function (chunks, encoding, callback) {
     }
 
     this.nextSequenceToken = options.nextSequenceToken;
+
+    if (this.writeCompleteEvent) {
+      this.emit(this.writeCompleteEvent);
+    }
+
     return callback();
   };
 

--- a/lib/cloudwatch-stream.js
+++ b/lib/cloudwatch-stream.js
@@ -19,7 +19,6 @@ function CloudWatchStream (options) {
   this.logGroupName = options.group;
   this.logStreamName = options.stream || (options.prefix ? options.prefix + '-' : '') + os.hostname() + '-' + process.pid + '-' + new Date().getTime();
   this.nextSequenceToken = null;
-  this.writeCompleteEvent = options.write_complete_event || null;
 
   var awsOptions = {};
 
@@ -123,9 +122,7 @@ CloudWatchStream.prototype._write = function (chunks, encoding, callback) {
 
     this.nextSequenceToken = options.nextSequenceToken;
 
-    if (this.writeCompleteEvent) {
-      this.emit(this.writeCompleteEvent);
-    }
+    this.emit('flushed');
 
     return callback();
   };


### PR DESCRIPTION
1. Handling for `InvalidSequenceTokenException` (multiple instances running / logging in the same time on the same stream -> concurrency)
2. Attach handlers to different writable stream events
3. Emit an event once the logs are successfully push / save in AWS CloudWatch