### PR TITLE
Check for invalidSequenceTokenException and retry with new sequence

### DIFF
--- a/lib/cloudwatch-stream.js
+++ b/lib/cloudwatch-stream.js
@@ -93,12 +93,21 @@ CloudWatchStream.prototype.nextToken = function (options, callback) {
 };
 
 CloudWatchStream.prototype.putLogEvents = function (options, callback) {
+  var self = this;
+
   this.cloudWatchLogs.putLogEvents({
     logEvents: options.logEvents,
     logGroupName: options.logGroupName,
     logStreamName: options.logStreamName,
     sequenceToken: options.nextSequenceToken
   }, function (err, data) {
+    if (err && err.code === 'InvalidSequenceTokenException') {
+      var body = JSON.parse(this.httpResponse.body.toString());
+      options.nextSequenceToken = body.expectedSequenceToken;
+
+      return self.putLogEvents(options, callback);
+    }
+
     options.nextSequenceToken = data && data.nextSequenceToken;
     callback(err, options);
   });
@@ -115,6 +124,7 @@ CloudWatchStream.prototype._write = function (chunks, encoding, callback) {
     }
 
     this.nextSequenceToken = options.nextSequenceToken;
+
     return callback();
   };
 

--- a/test/mocks/cloudwatch-logs.js
+++ b/test/mocks/cloudwatch-logs.js
@@ -1,10 +1,25 @@
+const invalidSequenceTokenError = {
+  code: 'InvalidSequenceTokenException'
+};
 
-function CloudWatchLogs (/*options*/) {
+const invalidSequenceTokenRequest = {
+  httpResponse: {
+    body: '{"expectedSequenceToken": 1000}'
+  }
+};
 
+function CloudWatchLogs (options) {
+  this.mode = options.region;
 }
 
 CloudWatchLogs.prototype.putLogEvents = function (options, callback) {
-  callback();
+  if (this.mode === 'InvalidSequenceTokenException' && options.sequenceToken === 1) {
+    var cb = callback.bind(invalidSequenceTokenRequest);
+
+    return cb(invalidSequenceTokenError, null);
+  }
+
+  callback(null, { nextSequenceToken: options.sequenceToken++ });
 };
 
 CloudWatchLogs.prototype.createLogGroup = function (options, callback) {

--- a/test/specs/cloudwatch-stream.spec.js
+++ b/test/specs/cloudwatch-stream.spec.js
@@ -29,4 +29,13 @@ describe('cloudwatch-stream', function () {
       done(err);
     });
   });
+
+  it('should recover from an InvalidSequenceTokenException', function (done) {
+    var stream = new CloudWatchStream({ group: 'test', aws_region: 'InvalidSequenceTokenException' });
+    var inStream = fs.createReadStream(path.resolve(__dirname, '../mocks/logs.txt'));
+
+    pump(inStream, split(), stream, function (err) {
+      done(err);
+    });
+  });
 });


### PR DESCRIPTION
Part of #29 

Handles the `invalidSequenceTokenException` exception.