### PR TITLE
Fixed missing default interval for Stream usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ var CloudWatchStream = require('./lib/cloudwatch-stream');
 module.exports = function (options, errorHandler) {
   options = options || {};
   options.ignoreEmpty = true;
+  options.interval = typeof options.interval === 'undefined'
+    ? 1000
+    : options.interval;
 
   var log = new CloudWatchStream(options);
   var chunk = new ChunkyStream(options);


### PR DESCRIPTION
I stumbled upon an issue where [pino-cloudwatch](https://github.com/dbhowell/pino-cloudwatch) as a Writable Stream would result in no reported events. That's because the default interval is only set when running through `bin/pino-cloudwatch.js` and not when it's directly imported. `undefined` interval would result in a failed `this.interval > 0` check in `chunky-stream` resulting in skipped setTimeout and thus no reported events. Adding a default value fixed the issue.