### PR TITLE
Expose AWS Endpoint to config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Options:
   --aws_access_key_id      AWS Access Key ID
   --aws_secret_access_key  AWS Secret Access Key
   --aws_region             AWS Region
+  --aws_endpoint           AWS Endpoint
   --group                  AWS CloudWatch log group name              [required]
   --prefix                 AWS CloudWatch log stream name prefix
   --stream                 AWS CloudWatch log stream name, overrides --prefix option.
@@ -55,6 +56,8 @@ __note__: Disabling the interval could mean that logs will *never* be sent to Cl
 ### `aws_secret_access_key`: `String`
 
 ### `aws_region`: `String`
+
+### `aws_endpoint`: `String`
 
 ## Other uses
 

--- a/lib/cloudwatch-stream.js
+++ b/lib/cloudwatch-stream.js
@@ -22,11 +22,12 @@ function CloudWatchStream (options) {
 
   var awsOptions = {};
 
-  if (options.aws_region || options.aws_access_key_id || options.aws_secret_access_key) {
+  if (options.aws_region || options.aws_access_key_id || options.aws_secret_access_key || options.aws_endpoint) {
     awsOptions = {
       region: options.aws_region,
       accessKeyId: options.aws_access_key_id,
-      secretAccessKey: options.aws_secret_access_key
+      secretAccessKey: options.aws_secret_access_key,
+      endpoint: options.aws_endpoint,
     };
   }
 


### PR DESCRIPTION
Allow pointing SDK to local services e.g localstack for testing/development